### PR TITLE
fix path

### DIFF
--- a/utils/create.js
+++ b/utils/create.js
@@ -46,6 +46,7 @@ export default function create(store, option) {
     } else {
         const ready = store.ready
         const pure = store.pure
+        const componentUpdatePath = getUpdatePath(store.data)
         store.ready = function () {
             if (pure) {
                 this.store = { data: store.data || {} }
@@ -55,7 +56,7 @@ export default function create(store, option) {
             } else {
                 this.page = getCurrentPages()[getCurrentPages().length - 1]
                 this.store = this.page.store
-                this._updatePath = getUpdatePath(store.data)
+                this._updatePath = componentUpdatePath
                 syncValues(this.store.data, store.data)
                 walk(store.data || {})
                 this.setData.call(this, this.store.data)


### PR DESCRIPTION
如果一个组件用wx:if进行判断展示，如果多次展示，在store.ready的回调函数中进行更新路径的赋值，会出现更新路径被上一次展示的数据污染，导致组件无法根据所写的data，进行有效更新。