### PR TITLE
解决执行navigateBack或reLaunch时清除store.instances对应页面的实例

### DIFF
--- a/utils/create.js
+++ b/utils/create.js
@@ -44,6 +44,14 @@ export default function create(store, option) {
             syncValues(store.data, this.data)
             this.setData(this.data)
         }
+	
+	// 解决执行navigateBack或reLaunch时清除store.instances对应页面的实例
+	const onUnload = option.onUnload
+        option.onUnload = function () {
+            onUnload && onUnload.call(this)
+            store.instances[this.route] = []
+        }
+
         Page(option)
     } else {
         const ready = store.ready


### PR DESCRIPTION
执行navigateBack的时候没有及时清除globalStore.instances 使update执行后有处于padding状态的情况，导致Promise.all 无法resolve