### PR TITLE
修复：对数组使用unshift、spilce方法会导致数据有误

### DIFF
--- a/utils/create.js
+++ b/utils/create.js
@@ -218,7 +218,7 @@ function update(patch) {
                             const _diffResult = {}
                             for (let _path in diffResult) {
                                 if (needUpdatePathList.includes(_path)) {
-                                    _diffResult[_path] = diffResult[_path]
+                                    _diffResult[_path] = typeof diffResult[_path] === 'object' ? JSON.parse(JSON.stringify(diffResult[_path])) : diffResult[_path]
                                 }
                             }
                             array.push( new Promise(cb => {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/25034156/55374154-0ca33f00-553a-11e9-844e-801406bf4b41.png)

当在数组插入数据（除了尾部），经过diff算法后会输出这样的结构：
`
// 假设数组原本有10项，头部插入一项
{
 // ...
  "list[9].title": "xxxx",
  "list[9].id": "5364de7c",
  "list[10]": { "id": "8729aec2", title: "yyyy" }
}
`
这里的第11项其实是指向原本的第10项的内存地址。

然后进行setData时候，按照这样的顺序一项处理。到处理“list[9].xxx”的结果时，VM更新了原本第10项的数据，同时更改了this.data的第10项的内存指向，导致“list[10]”这一项后面的这个对象改变了。
