### PR TITLE
Update diff.js

### DIFF
--- a/packages/westore/utils/diff.js
+++ b/packages/westore/utils/diff.js
@@ -91,8 +91,13 @@ function _diff(current, pre, path, result) {
 }
 
 function setResult(result, k, v) {
-    if (type(v) != FUNCTIONTYPE) {
-        result[k] = v
+    let vtype = type(v)
+    if (vtype === OBJECTTYPE) {
+    result[k] = {...v}
+    } else if (vtype === ARRAYTYPE) {
+    result[k] = [...v]
+    } else if (vtype != FUNCTIONTYPE){
+    result[k] = v
     }
 }
 


### PR DESCRIPTION
修复bug：数组元素是对象时，像数组头部插入元素，数组尾部的两个元素会有相同的引用