### PR TITLE
删除 create.js 中多余的判断

### DIFF
--- a/utils/create.js
+++ b/utils/create.js
@@ -145,9 +145,6 @@ function rewritePureUpdate(ctx) {
             }
             let diffResult = diff(store.data, store.originData)
             let array = []
-            if (Object.keys(diffResult)[0] == '') {
-                diffResult = diffResult['']
-            }
             if (Object.keys(diffResult).length > 0) {
                 array.push( new Promise( cb => that.setData(diffResult, cb) ) )
                 store.onChange && store.onChange(diffResult)


### PR DESCRIPTION
https://github.com/zwmmm/westore/blob/master/utils/diff.js#L41 中已经判断过 path === '' 的情况，所以create.js 中不需要再处理 path === '' 的情况