### PR TITLE
fix: An operator precedence bug introduced in #110.

### DIFF
--- a/utils/diff.js
+++ b/utils/diff.js
@@ -67,7 +67,7 @@ function _diff(current, pre, path, result) {
                         setResult(result, concatPathAndKey(path, key), currentValue)
                     } else {
                         for (let subKey in currentValue) {
-                            const realPath = concatPathAndKey(path, key) + subKey.includes('.') ? `["${subKey}"]` : `.${subKey}`
+                            const realPath = concatPathAndKey(path, key) + (subKey.includes('.') ? `["${subKey}"]` : `.${subKey}`)
                             _diff(currentValue[subKey], preValue[subKey], realPath, result)
                         }
                     }


### PR DESCRIPTION
``` javascript
const prev = { a: { b: null } }
const cur = { a: { b: 1 } }
console.log( diff(cur, prev) )
// result: {b: 1}
// expect: {"a.b": 1}
```
