### PR TITLE
fix: ts实例中logStore的用例

### DIFF
--- a/packages/westore-example-ts/miniprogram/models/log.ts
+++ b/packages/westore-example-ts/miniprogram/models/log.ts
@@ -1,7 +1,12 @@
 import * as util from "../utils/util";
 
+export interface LogItem {
+  data: string
+  timeStamp: string | number
+}
+
 export class Log {
-  logs: (string | number)[];
+  logs: LogItem[];
   constructor() {
     this.logs = [];
   }

--- a/packages/westore-example-ts/miniprogram/pages/logs/logs.ts
+++ b/packages/westore-example-ts/miniprogram/pages/logs/logs.ts
@@ -1,19 +1,12 @@
 // logs.ts
-// const util = require('../../utils/util.js')
-import { formatTime } from '../../utils/util'
+import logStore from '../../stores/log-store'
 
 Page({
   data: {
-    logs: [],
+    logs: logStore.data,
   },
   onLoad() {
-    this.setData({
-      logs: (wx.getStorageSync('logs') || []).map((log: string) => {
-        return {
-          date: formatTime(new Date(log)),
-          timeStamp: log
-        }
-      }),
-    })
+    logStore.bind("logPage", this);
+    logStore.loadLogs();
   },
 })


### PR DESCRIPTION
ts示例中logStore的用法有误
![image](https://github.com/user-attachments/assets/20394376-ecb9-472d-a795-7c5966777dbb)
